### PR TITLE
Fix "Too many authentication failures" error

### DIFF
--- a/run
+++ b/run
@@ -70,6 +70,7 @@ you should probably add to your .ssh/config file:
 	    Hostname localhost
 	    Port 4405
 	    IdentityFile ${dir}/docker/home/.ssh/id_rsa
+	    IdentitiesOnly yes
 	    StrictHostKeyChecking no
 	    UserKnownHostsFile /dev/null
 


### PR DESCRIPTION
I encountered the following error recently

akaros-devel-docker> ssh akaros-devel 
Warning: Permanently added '[localhost]:4405' (ECDSA) to the list of known hosts.
Received disconnect from ::1: 2: Too many authentication failures for _myusername_

Adding the "IdentitiesOnly" line solved the problem.
